### PR TITLE
Update to use new dimension aliases {Ix1, Ix2} everywhere

### DIFF
--- a/examples/poly_fit.rs
+++ b/examples/poly_fit.rs
@@ -19,7 +19,7 @@ extern crate rand;
 use rand::thread_rng;
 use rand::distributions::{Normal, Sample};
 use linxal::least_squares::LeastSquares;
-use ndarray::{Array, arr1, Ix};
+use ndarray::{Array, arr1, Ix1};
 
 /// Evalutate a polynomial f with coefficients `coefs` at `x`.
 ///
@@ -30,7 +30,7 @@ fn eval_poly(x: f32, coefs: &[f32]) -> f32 {
 }
 
 /// Returns the row (1.0, x, x^2, ..., x^n)
-fn vandermonde_row(x: f32, n: usize) -> Array<f32, Ix> {
+fn vandermonde_row(x: f32, n: usize) -> Array<f32, Ix1> {
     let mut v: Vec<f32> = Vec::with_capacity(n + 1);
     let mut r = 1.0;
     v.push(1.0);

--- a/examples/poly_interp.rs
+++ b/examples/poly_interp.rs
@@ -11,7 +11,7 @@ extern crate rand;
 use rand::thread_rng;
 use rand::distributions::{Range, IndependentSample};
 use linxal::solve_linear::SolveLinear;
-use ndarray::{Array, Ix};
+use ndarray::{Array, Ix1};
 
 /// Evalutate a polynomial f with coefficients `coefs` at `x`.
 ///
@@ -22,7 +22,7 @@ fn eval_poly(x: f32, coefs: &[f32]) -> f32 {
 }
 
 /// Returns the row (1.0, x, x^2, ..., x^n)
-fn vandermonde_row(x: f32, n: usize) -> Array<f32, Ix> {
+fn vandermonde_row(x: f32, n: usize) -> Array<f32, Ix1> {
     let mut v: Vec<f32> = Vec::with_capacity(n + 1);
     let mut r = 1.0;
     v.push(1.0);

--- a/src/eigenvalues/symmetric.rs
+++ b/src/eigenvalues/symmetric.rs
@@ -15,13 +15,13 @@ pub trait SymEigen: Sized {
     fn compute_mut<D>(mat: &mut ArrayBase<D, Ix2>,
                       uplo: Symmetric,
                       with_vectors: bool)
-                      -> Result<Array<Self::SingularValue, Ix>, EigenError>
+                      -> Result<Array<Self::SingularValue, Ix1>, EigenError>
         where D: DataMut<Elem = Self>;
 
     /// Return the real eigenvalues of a symmetric matrix.
     fn compute_into<D>(mut mat: ArrayBase<D, Ix2>,
                        uplo: Symmetric)
-                       -> Result<Array<Self::SingularValue, Ix>, EigenError>
+                       -> Result<Array<Self::SingularValue, Ix1>, EigenError>
         where D: DataMut<Elem = Self> + DataOwned<Elem = Self> {
         Self::compute_mut(&mut mat, uplo, false)
     }
@@ -46,7 +46,7 @@ macro_rules! impl_sym_eigen {
             type Solution = Solution<Self, Self::SingularValue>;
 
             fn compute_mut<D>(mat: &mut ArrayBase<D, Ix2>, uplo: Symmetric, with_vectors: bool) ->
-                Result<Array<Self::SingularValue, Ix>, EigenError>
+                Result<Array<Self::SingularValue, Ix1>, EigenError>
                 where D: DataMut<Elem=Self>
             {
                 let dim = mat.dim();

--- a/src/eigenvalues/types.rs
+++ b/src/eigenvalues/types.rs
@@ -1,4 +1,5 @@
 use ndarray::prelude::*;
+use ndarray::{Ix1, Ix2};
 
 /// Errors from an eigenvalue problem.
 #[derive(Debug)]
@@ -15,7 +16,7 @@ pub enum EigenError {
 /// eigenvectors of the solution. For symmetric problems, the
 /// eigenvectors are placed in `right_eigenvectors`.
 pub struct Solution<IV, EV> {
-    pub values: Array<EV, Ix>,
-    pub left_vectors: Option<Array<IV, (Ix, Ix)>>,
-    pub right_vectors: Option<Array<IV, (Ix, Ix)>>,
+    pub values: Array<EV, Ix1>,
+    pub left_vectors: Option<Array<IV, Ix2>>,
+    pub right_vectors: Option<Array<IV, Ix2>>,
 }

--- a/src/impl_prelude.rs
+++ b/src/impl_prelude.rs
@@ -1,5 +1,5 @@
 pub use ndarray::prelude::*;
-pub use ndarray::{Data, DataMut, DataOwned, Ix2};
+pub use ndarray::{Data, DataMut, DataOwned, Ix1, Ix2};
 pub use util::internal::*;
 pub use lapack::{c32, c64};
 pub use types::Symmetric;

--- a/src/least_squares.rs
+++ b/src/least_squares.rs
@@ -142,8 +142,8 @@ pub trait LeastSquares: Sized + Clone {
     ///
     /// This method will never return `LeastSquaresError::Degenerate`.
     fn compute<D1, D2>(a: &ArrayBase<D1, Ix2>,
-                       b: &ArrayBase<D2, Ix>)
-                       -> Result<LeastSquaresSolution<Self, Ix>, LeastSquaresError>
+                       b: &ArrayBase<D2, Ix1>)
+                       -> Result<LeastSquaresSolution<Self, Ix1>, LeastSquaresError>
         where D1: Data<Elem = Self>,
               D2: Data<Elem = Self>
     {
@@ -256,7 +256,7 @@ macro_rules! impl_least_squares {
                     None => return Err(LeastSquaresError::BadLayout)
                 };
 
-                let mut svs: Array<$sv_type, Ix> = Array::default(cmp::min(a_dim.0, a_dim.1));
+                let mut svs: Array<$sv_type, Ix1> = Array::default(cmp::min(a_dim.0, a_dim.1));
                 let mut rank: i32 = 0;
 
 // compute result

--- a/src/solve_linear/general.rs
+++ b/src/solve_linear/general.rs
@@ -16,8 +16,8 @@ pub trait SolveLinear: Sized + Clone {
 
     /// Solve the linear system A * x = b for square matrix `a` and column vector `b`.
     fn compute_into<D1, D2>(a: ArrayBase<D1, Ix2>,
-                            b: ArrayBase<D2, Ix>)
-                            -> Result<ArrayBase<D2, Ix>, SolveError>
+                            b: ArrayBase<D2, Ix1>)
+                            -> Result<ArrayBase<D2, Ix1>, SolveError>
         where D1: DataMut<Elem = Self> + DataOwned<Elem = Self>,
               D2: DataMut<Elem = Self> + DataOwned<Elem = Self>
     {
@@ -51,8 +51,8 @@ pub trait SolveLinear: Sized + Clone {
 
     /// Solve the linear system A * x = b for square matrix `a` and column vector `b`.
     fn compute<D1, D2>(a: &ArrayBase<D1, Ix2>,
-                       b: &ArrayBase<D2, Ix>)
-                       -> Result<Array<Self, Ix>, SolveError>
+                       b: &ArrayBase<D2, Ix1>)
+                       -> Result<Array<Self, Ix1>, SolveError>
         where D1: Data<Elem = Self>,
               D2: Data<Elem = Self>
     {
@@ -93,7 +93,7 @@ macro_rules! impl_solve_linear {
                         None => return Err(SolveError::InconsistentLayout)
                     };
 
-                    let mut perm: Array<i32, Ix> = Array::default(dim.0);
+                    let mut perm: Array<i32, Ix1> = Array::default(dim.0);
 
                     $driver(layout, dim.0 as i32, b_dim.1 as i32,
                            slice, lda as i32,

--- a/src/solve_linear/symmetric.rs
+++ b/src/solve_linear/symmetric.rs
@@ -19,8 +19,8 @@ pub trait SymmetricSolveLinear: Sized + Clone {
     /// square matrix `a` and column vector `b`.
     fn compute_into<D1, D2>(a: ArrayBase<D1, Ix2>,
                             uplo: Symmetric,
-                            b: ArrayBase<D2, Ix>)
-                            -> Result<ArrayBase<D2, Ix>, SolveError>
+                            b: ArrayBase<D2, Ix1>)
+                            -> Result<ArrayBase<D2, Ix1>, SolveError>
         where D1: DataMut<Elem = Self> + DataOwned<Elem = Self>,
               D2: DataMut<Elem = Self> + DataOwned<Elem = Self>
     {
@@ -58,8 +58,8 @@ pub trait SymmetricSolveLinear: Sized + Clone {
     /// square matrix `a` and column vector `b`.
     fn compute<D1, D2>(a: &ArrayBase<D1, Ix2>,
                        uplo: Symmetric,
-                       b: &ArrayBase<D2, Ix>)
-                       -> Result<Array<Self, Ix>, SolveError>
+                       b: &ArrayBase<D2, Ix1>)
+                       -> Result<Array<Self, Ix1>, SolveError>
         where D1: Data<Elem = Self>,
               D2: Data<Elem = Self>
     {
@@ -102,7 +102,7 @@ macro_rules! impl_solve_linear {
                         None => return Err(SolveError::InconsistentLayout)
                     };
 
-                    let mut perm: Array<i32, Ix> = Array::default(dim.0);
+                    let mut perm: Array<i32, Ix1> = Array::default(dim.0);
 
                     $driver(layout, uplo as u8, dim.0 as i32, b_dim.1 as i32,
                             slice, lda as i32,

--- a/src/svd/types.rs
+++ b/src/svd/types.rs
@@ -1,6 +1,7 @@
 use ndarray::prelude::*;
 use num_traits::{Float, ToPrimitive};
 use std::fmt::Display;
+use ndarray::{Ix1, Ix2};
 
 /// Trait for singular values
 ///
@@ -21,15 +22,15 @@ pub struct SVDSolution<IV: Sized, SV: Sized> {
     ///
     /// Singular values, which are guaranteed to be non-negative
     /// reals, are returned in descending order.
-    pub values: Array<SV, Ix>,
+    pub values: Array<SV, Ix1>,
 
     /// The matrix `U` of left singular vectors.
-    pub left_vectors: Option<Array<IV, (Ix, Ix)>>,
+    pub left_vectors: Option<Array<IV, Ix2>>,
 
     /// The matrix V^t of singular vectors.
     ///
     /// The transpose of V is stored, not V itself.
-    pub right_vectors: Option<Array<IV, (Ix, Ix)>>,
+    pub right_vectors: Option<Array<IV, Ix2>>,
 }
 
 /// An error resulting from a `SVD::compute*` method.

--- a/tests/solve_linear.rs
+++ b/tests/solve_linear.rs
@@ -4,14 +4,14 @@ extern crate ndarray;
 extern crate linxal;
 extern crate lapack;
 
-use ndarray::{Array, Ix, Ix2, Axis};
+use ndarray::{Array, Ix1, Ix2, Axis};
 use linxal::solve_linear::{SolveLinear};
 use linxal::types::{Magnitude};
 
 #[test]
 pub fn solve_linear_vector() {
     let a: Array<f32, Ix2> = Array::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0]).unwrap();
-    let b: Array<f32, Ix> = Array::from_vec(vec![3.0, 7.0]);
+    let b: Array<f32, Ix1> = Array::from_vec(vec![3.0, 7.0]);
 
     let x = SolveLinear::compute_into(a, b);
 


### PR DESCRIPTION
The change from Ix → Ix1 is unfortunately needed. This is compatible with ndarray 0.6.8 and is intended to be compatible with (in development) 0.7.x.